### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -62,8 +62,8 @@ off	KEYWORD2
 cw	KEYWORD2
 ccw	KEYWORD2
 
-getCelsiusTemp KEYWORD2
-getFahrenheitTemp KEYWORD2
+getCelsiusTemp	KEYWORD2
+getFahrenheitTemp	KEYWORD2
 
 drawPixel	KEYWORD2
 writeDisplay	KEYWORD2
@@ -140,7 +140,7 @@ getMinute	KEYWORD2
 getHour	KEYWORD2
 getWeek	KEYWORD2
 getDay	KEYWORD2
-getMonth KEYWORD2
+getMonth	KEYWORD2
 getYear	KEYWORD2
 fillByHMS	KEYWORD2
 fillByYMD	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords